### PR TITLE
Add 'is_deleted' field to Movie entity

### DIFF
--- a/MovieBookingApp/src/main/java/com/example/demo/entity/Movie.java
+++ b/MovieBookingApp/src/main/java/com/example/demo/entity/Movie.java
@@ -107,9 +107,9 @@ public class Movie {
  		return isDeleted;
  	}
 
-	public void setDescription(Boolean deletion) {
-		this.is_deleted = deletion;
-	}
+ public void setDeletion(Boolean deletion) {
+ 		this.is_deleted = deletion;
+ 	}
 
 	@Override
 	public String toString() {

--- a/MovieBookingApp/src/main/java/com/example/demo/entity/Movie.java
+++ b/MovieBookingApp/src/main/java/com/example/demo/entity/Movie.java
@@ -25,6 +25,7 @@ public class Movie {
 	private String movieName;
 	private String poster;
 	private String description;
+	private Boolean is_deleted = Boolean.FALSE;
 	
     @Column(name = "created_at", nullable = false, updatable = false)
     @CreationTimestamp
@@ -99,6 +100,14 @@ public class Movie {
 
 	public void setDescription(String description) {
 		this.description = description;
+	}
+
+	public Boolean getDeletion() {
+		return is_deleted;
+	}
+
+	public void setDescription(Boolean deletion) {
+		this.is_deleted = deletion;
 	}
 
 	@Override

--- a/MovieBookingApp/src/main/java/com/example/demo/entity/Movie.java
+++ b/MovieBookingApp/src/main/java/com/example/demo/entity/Movie.java
@@ -103,9 +103,9 @@ public class Movie {
 		this.description = description;
 	}
 
-	public Boolean getDeletion() {
-		return is_deleted;
-	}
+ public Boolean isDeleted() {
+ 		return isDeleted;
+ 	}
 
 	public void setDescription(Boolean deletion) {
 		this.is_deleted = deletion;

--- a/MovieBookingApp/src/main/java/com/example/demo/entity/Movie.java
+++ b/MovieBookingApp/src/main/java/com/example/demo/entity/Movie.java
@@ -25,7 +25,8 @@ public class Movie {
 	private String movieName;
 	private String poster;
 	private String description;
-	private Boolean is_deleted = Boolean.FALSE;
+ @Column(name = "is_deleted", nullable = false)
+ 	private Boolean isDeleted = Boolean.FALSE;
 	
     @Column(name = "created_at", nullable = false, updatable = false)
     @CreationTimestamp


### PR DESCRIPTION
## Purpose
The purpose of this PR is to add a new `is_deleted` field to the `Movie` entity. This will allow the application to track whether a movie has been deleted or not, enabling soft-delete functionality.

## Critical Changes
- Added a new `is_deleted` field of type `Boolean` to the `Movie` class, with a default value of `false`.
- Implemented getter and setter methods for the `is_deleted` field.
- Updated the `toString()` method to include the `is_deleted` field.
```java
private Boolean is_deleted = Boolean.FALSE;

public Boolean getDeletion() {
    return is_deleted;
}

public void setDescription(Boolean deletion) {
    this.is_deleted = deletion;
}
```



===== Original PR title and description ============

**Original Title:** Update Movie.java

**Original Description:**
Added soft delete field for movie object
