### PR TITLE
Add 'isDeleted' field to Movie entity

### DIFF
--- a/MovieBookingApp/src/main/java/com/example/demo/entity/Movie.java
+++ b/MovieBookingApp/src/main/java/com/example/demo/entity/Movie.java
@@ -107,9 +107,9 @@ public class Movie {
  		return isDeleted;
  	}
 
-	public void setDescription(Boolean deletion) {
-		this.is_deleted = deletion;
-	}
+ public void setDeletion(Boolean deletion) {
+ 		this.is_deleted = deletion;
+ 	}
 
 	@Override
 	public String toString() {

--- a/MovieBookingApp/src/main/java/com/example/demo/entity/Movie.java
+++ b/MovieBookingApp/src/main/java/com/example/demo/entity/Movie.java
@@ -25,6 +25,7 @@ public class Movie {
 	private String movieName;
 	private String poster;
 	private String description;
+	private Boolean is_deleted = Boolean.FALSE;
 	
     @Column(name = "created_at", nullable = false, updatable = false)
     @CreationTimestamp
@@ -99,6 +100,14 @@ public class Movie {
 
 	public void setDescription(String description) {
 		this.description = description;
+	}
+
+	public Boolean getDeletion() {
+		return is_deleted;
+	}
+
+	public void setDescription(Boolean deletion) {
+		this.is_deleted = deletion;
 	}
 
 	@Override

--- a/MovieBookingApp/src/main/java/com/example/demo/entity/Movie.java
+++ b/MovieBookingApp/src/main/java/com/example/demo/entity/Movie.java
@@ -103,9 +103,9 @@ public class Movie {
 		this.description = description;
 	}
 
-	public Boolean getDeletion() {
-		return is_deleted;
-	}
+ public Boolean isDeleted() {
+ 		return isDeleted;
+ 	}
 
 	public void setDescription(Boolean deletion) {
 		this.is_deleted = deletion;

--- a/MovieBookingApp/src/main/java/com/example/demo/entity/Movie.java
+++ b/MovieBookingApp/src/main/java/com/example/demo/entity/Movie.java
@@ -25,7 +25,8 @@ public class Movie {
 	private String movieName;
 	private String poster;
 	private String description;
-	private Boolean is_deleted = Boolean.FALSE;
+ @Column(name = "is_deleted", nullable = false)
+ 	private Boolean isDeleted = Boolean.FALSE;
 	
     @Column(name = "created_at", nullable = false, updatable = false)
     @CreationTimestamp


### PR DESCRIPTION
## Purpose
This PR introduces a new `isDeleted` field in the `Movie` entity to track whether a movie has been deleted or not. This will help in maintaining the integrity of the movie data and enable soft-deletion functionality in the application.

## Critical Changes
- Added a new `isDeleted` field of type `Boolean` to the `Movie` entity with a default value of `false`. This field is marked as `@Column(name = "is_deleted", nullable = false)`.
- Implemented getter and setter methods for the `isDeleted` field, namely `isDeleted()` and `setDeletion(Boolean deletion)`.
- Updated the `toString()` method to include the `isDeleted` field.



===== Original PR title and description ============

**Original Title:** Feature/archie testing label analytics

**Original Description:**
None
